### PR TITLE
Add USB config options

### DIFF
--- a/tcl/interface/dirtyjtag.cfg
+++ b/tcl/interface/dirtyjtag.cfg
@@ -1,2 +1,2 @@
-interface dirtyjtag
-adapter_khz 100
+adapter driver dirtyjtag
+adapter speed 100


### PR DESCRIPTION
The ability to specify VID, PID, EP numbers, and interface number is very useful for customized DirtyJTAG ports where more endpoints are specified for other functions and the programmer wishes to organize endpoints and interfaces differently.

These changes are transparent by default. The driver will work without them but it is nice to have the option. I tested it on a custom RPi Pico port using TinyUSB which uses different VID, PID, EPIN, EPOUT, and ITF_NUM values.